### PR TITLE
Adjust iframe height for squarespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,5 +113,16 @@
     <script src="data/benefits.js"></script>
     <script src="data/illustrations.js"></script>
     <script src="js/main.js"></script>
+    
+    <script>
+      function sendHeight() {
+        const height = document.documentElement.scrollHeight || document.body.scrollHeight;
+        parent.postMessage({ type: 'setHeight', height: height }, '*');
+      }
+
+      window.addEventListener('load', sendHeight);
+      window.addEventListener('resize', sendHeight);
+      setInterval(sendHeight, 1000); // fallback for dynamic content changes
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Add script to `index.html` to enable iframe height adjustment for Squarespace embedding.

---

[Open in Web](https://cursor.com/agents?id=bc-919bf7f1-963d-425f-a928-4abb3d70014a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-919bf7f1-963d-425f-a928-4abb3d70014a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)