### PR TITLE
Apply utm to pricing buttons from config

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -165,7 +165,7 @@ function populatePricing() {
                         ${plan.features.map(feature => `<li>${feature}</li>`).join('')}
                     </ul>
                     <a
-                      href="${config.eventUrl}"
+                      href="${window.buildLumaUrl()}"
                       class="cta-button"
                       target="_blank"
                       rel="noopener noreferrer"


### PR DESCRIPTION
Apply UTM parameters to pricing section buttons to ensure consistent analytics tracking.

Previously, pricing buttons used a direct URL, while other CTA buttons used `buildLumaUrl()` which includes UTMs. This change ensures all relevant buttons track consistently.

---

[Open in Web](https://cursor.com/agents?id=bc-ddefa0ea-dabc-41f7-9492-a4f44205b96d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ddefa0ea-dabc-41f7-9492-a4f44205b96d) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)