### PR TITLE
chore: remove stale dead code

### DIFF
--- a/config/workshops-index-config.js
+++ b/config/workshops-index-config.js
@@ -79,33 +79,10 @@ const WORKSHOPS_INDEX_CONFIG = {
     }
 };
 
-// Helper function to get workshop by ID
-function getWorkshopById(id) {
-    return WORKSHOPS_INDEX_CONFIG.workshops.find(workshop => workshop.id === id);
-}
-
-// Helper function to get workshop by slug
-function getWorkshopBySlug(slug) {
-    return WORKSHOPS_INDEX_CONFIG.workshops.find(workshop => workshop.slug === slug);
-}
-
-// Helper function to get active workshops only
-function getActiveWorkshops() {
-    return WORKSHOPS_INDEX_CONFIG.workshops.filter(workshop => workshop.status === 'active');
-}
-
 // Export for use in other files (if using modules)
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { 
-        WORKSHOPS_INDEX_CONFIG, 
-        getWorkshopById, 
-        getWorkshopBySlug, 
-        getActiveWorkshops 
-    };
+    module.exports = { WORKSHOPS_INDEX_CONFIG };
 }
 
 // Make available globally for inline use
 window.WORKSHOPS_INDEX_CONFIG = WORKSHOPS_INDEX_CONFIG;
-window.getWorkshopById = getWorkshopById;
-window.getWorkshopBySlug = getWorkshopBySlug;
-window.getActiveWorkshops = getActiveWorkshops;

--- a/css/styles.css
+++ b/css/styles.css
@@ -441,23 +441,6 @@ body {
     margin-bottom: 30px;
 }
 
-/* ===== FOOTER ===== */
-.footer {
-    text-align: center;
-    padding: 40px 20px;
-    color: #666;
-    border-top: 1px solid #e0e0e0;
-}
-
-.footer a {
-    color: #1a1a1a;
-    text-decoration: none;
-}
-
-.footer a:hover {
-    text-decoration: underline;
-}
-
 /* ===== RESPONSIVE DESIGN ===== */
 @media (max-width: 768px) {
     .workshop-title {

--- a/js/workshop-index.js
+++ b/js/workshop-index.js
@@ -77,13 +77,6 @@ function populateWorkshopsGrid() {
     }
 }
 
-// Add click tracking for analytics (if needed)
-function trackWorkshopClick(workshopId) {
-    console.log('Workshop clicked:', workshopId);
-    // You can add analytics tracking here
-    // Example: gtag('event', 'workshop_click', { workshop_id: workshopId });
-}
-
 // Add hover effects for workshop cards
 document.addEventListener('mouseover', function(e) {
     if (e.target.closest('.workshop-card')) {


### PR DESCRIPTION
## Summary

Removes three speculative, never-wired symbols surfaced by `/codebase-audit` (#12). Each was confirmed dead by a repo-wide grep — none has a caller.

- **`css/styles.css`** — deleted the `.footer` / `.footer a` / `.footer a:hover` block. No markup uses `.footer`; the only footer in the repo is `index.html`'s `.workshop-index-footer`, styled separately in `css/workshop-index.css`.
- **`js/workshop-index.js`** — deleted `trackWorkshopClick(workshopId)`, defined but never called (only logged to console behind an "if needed" comment).
- **`config/workshops-index-config.js`** — deleted `getWorkshopById`, `getWorkshopBySlug`, `getActiveWorkshops` plus their `module.exports` entries and `window.*` bindings. The sole consumer, `js/workshop-index.js`, reads `window.WORKSHOPS_INDEX_CONFIG.workshops` directly, which is preserved.

Net: −49 / +2 lines, no behavioural change.

## Validation

- **Syntax:** `node --check` passes on both edited JS files.
- **Grep evidence:** repo-wide search confirms zero remaining callers of all four removed symbols and zero `class="footer"` usages.
- **Behavioural (headless Chrome render of `index.html`):** the workshop grid still populates with all **3 workshop cards**; console logs the expected `Workshop index page initialized successfully` and **no JS errors**; footer text intact. Screenshot confirms the page renders identically.
- **Sanity sweep:** `git diff` is scoped to exactly the three audit findings — no out-of-scope edits, no dependency changes, no weakened assertions.

Closes #12