### PR TITLE
fix: gate unreleased workshops behind coming-soon status

### DIFF
--- a/config/workshops-index-config.js
+++ b/config/workshops-index-config.js
@@ -44,7 +44,7 @@ const WORKSHOPS_INDEX_CONFIG = {
             ctaText: 'Learn More',
             ctaUrl: 'personal-branding.html',
             colorScheme: 'personal-branding',
-            status: 'active'
+            status: 'coming-soon'
         },
         {
             id: 'digital-leadership',
@@ -65,7 +65,7 @@ const WORKSHOPS_INDEX_CONFIG = {
             ctaText: 'Learn More',
             ctaUrl: 'digital-leadership.html',
             colorScheme: 'digital-leadership',
-            status: 'active'
+            status: 'coming-soon'
         }
     ],
     


### PR DESCRIPTION
## Summary

- Set `status: 'coming-soon'` for `personal-branding` and `digital-leadership` in `config/workshops-index-config.js`
- Both workshops have placeholder Luma event ids and a dummy YouTube id; visitors were being linked to pages with a broken ticket CTA and a broken video embed
- The index JS (`js/workshop-index.js:69-72`) already handles the `coming-soon` branch by rendering a greyed, non-clickable "Coming Soon" span — no JS changes needed

## Validation

- **3a Reproduction proof:** rendering logic traced — `workshop.status === 'active'` is now `false` for both workshops; the ternary falls to the `<span>` branch (greyed, `cursor: not-allowed`)
- **3b Syntax gate:** `node --check config/workshops-index-config.js` → SYNTAX OK
- **3e Behavioural:** `virtual-communication` (status: active) renders unchanged Learn More link; `personal-branding` and `digital-leadership` render "Coming Soon" span
- **3f Sanity sweep:** `git diff main...HEAD` shows exactly 2 lines changed (only the two `status` flags) — no other files, no accidental removals

Closes #14