### PR TITLE
feat: add per-workshop OG/Twitter social-preview meta to redirect shims

### DIFF
--- a/digital-leadership.html
+++ b/digital-leadership.html
@@ -6,6 +6,15 @@
     <meta name="robots" content="index, follow">
     <title>Digital Leadership Workshop - Roberto Ferraro</title>
     <meta name="description" content="Master the skills to lead teams and organizations in the digital era. Join Roberto Ferraro's workshop to become an effective digital leader.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://www.robertoferraro.net/digital-leadership">
+    <meta property="og:title" content="Digital Leadership: Lead with Impact in the Virtual World - Roberto Ferraro">
+    <meta property="og:description" content="Develop the essential leadership skills needed to inspire, motivate, and guide teams effectively in virtual and hybrid work environments.">
+    <meta property="og:image" content="https://www.robertoferraro.net/images/digital-leadership-preview.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Digital Leadership: Lead with Impact in the Virtual World - Roberto Ferraro">
+    <meta name="twitter:description" content="Develop the essential leadership skills needed to inspire, motivate, and guide teams effectively in virtual and hybrid work environments.">
+    <meta name="twitter:image" content="https://www.robertoferraro.net/images/digital-leadership-preview.jpg">
     <link rel="canonical" href="workshop.html?w=digital-leadership">
     <!--
       All three workshop pages are now driven by the single workshop.html

--- a/personal-branding.html
+++ b/personal-branding.html
@@ -6,6 +6,15 @@
     <meta name="robots" content="index, follow">
     <title>Build Your Personal Brand Workshop - Roberto Ferraro</title>
     <meta name="description" content="Create an authentic and compelling personal brand that opens doors. Join Roberto Ferraro's workshop to master personal branding in the digital age.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://www.robertoferraro.net/personal-branding">
+    <meta property="og:title" content="Build Your Personal Brand: Stand Out in the Digital Age - Roberto Ferraro">
+    <meta property="og:description" content="Discover how to build a powerful personal brand that authentically represents you and helps you achieve your professional goals.">
+    <meta property="og:image" content="https://www.robertoferraro.net/images/personal-branding-preview.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Build Your Personal Brand: Stand Out in the Digital Age - Roberto Ferraro">
+    <meta name="twitter:description" content="Discover how to build a powerful personal brand that authentically represents you and helps you achieve your professional goals.">
+    <meta name="twitter:image" content="https://www.robertoferraro.net/images/personal-branding-preview.jpg">
     <link rel="canonical" href="workshop.html?w=personal-branding">
     <!--
       All three workshop pages are now driven by the single workshop.html

--- a/virtual-communication.html
+++ b/virtual-communication.html
@@ -6,6 +6,15 @@
     <meta name="robots" content="index, follow">
     <title>Master Virtual Meetings Workshop - Roberto Ferraro</title>
     <meta name="description" content="Transform your online presence and make every virtual interaction count. Join Roberto Ferraro's workshop to master virtual communication.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://www.robertoferraro.net/virtual-communication">
+    <meta property="og:title" content="Master Virtual Meetings: From Boring to Brilliant - Roberto Ferraro">
+    <meta property="og:description" content="Learn to communicate effectively in virtual settings with practical tools you can use right away.">
+    <meta property="og:image" content="https://www.robertoferraro.net/images/virtual-communication-preview.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Master Virtual Meetings: From Boring to Brilliant - Roberto Ferraro">
+    <meta name="twitter:description" content="Learn to communicate effectively in virtual settings with practical tools you can use right away.">
+    <meta name="twitter:image" content="https://www.robertoferraro.net/images/virtual-communication-preview.jpg">
     <link rel="canonical" href="workshop.html?w=virtual-communication">
     <!--
       All three workshop pages are now driven by the single workshop.html


### PR DESCRIPTION
## Summary

- Adds `og:title`, `og:description`, `og:image`, `og:type`, `og:url` and `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image` to all three workshop redirect shims (`virtual-communication.html`, `personal-branding.html`, `digital-leadership.html`)
- Values sourced from each workshop's existing config file, so they stay in sync with what JS injects at runtime
- No-build static-site model preserved — pure HTML-only change

## Validation

- **Static markup check:** Parsed raw HTML (no JS) for all three files — confirmed 5 OG + 4 Twitter tags present per file with correct per-workshop values
- **Diff sanity sweep:** Only the 3 shim files changed, exactly 9 lines added per file, nothing else touched
- **No build step needed:** Pure static HTML; no lint/test suite applies

Closes #19