### PR TITLE
docs: correct workshop status for Personal Branding and Digital Leadership

### DIFF
--- a/WORKSHOP_STRUCTURE.md
+++ b/WORKSHOP_STRUCTURE.md
@@ -148,10 +148,10 @@ To update workshop content:
    - Focus: Mastering virtual meetings and online communication
    - Status: Available for booking
 
-2. **Personal Branding** - Active
+2. **Personal Branding** - Coming soon
    - Focus: Building authentic personal brands in the digital age
-   - Status: Available for booking
+   - Status: Coming soon (set `status: 'coming-soon'` in `config/workshops-index-config.js`)
 
-3. **Digital Leadership** - Active
+3. **Digital Leadership** - Coming soon
    - Focus: Leading teams effectively in virtual environments
-   - Status: Available for booking
+   - Status: Coming soon (set `status: 'coming-soon'` in `config/workshops-index-config.js`)


### PR DESCRIPTION
## Summary

- WORKSHOP_STRUCTURE.md lines 151-157 incorrectly marked Personal Branding and Digital Leadership as "Active / Available for booking"
- `config/workshops-index-config.js` sets `status: 'coming-soon'` for both (lines 47 and 68); only Virtual Communication is `'active'`
- Updated the "Current Workshops" section to reflect the actual shipped config, and added an inline pointer to `workshops-index-config.js` as the canonical source to reduce future drift

## Validation

- 3b: Pure markdown change -- no syntax gate applicable
- 3e: Verified both entries now match `workshops-index-config.js` exactly; Virtual Communication entry (status: active -> Available for booking) left unchanged and correct
- 3f: Diff scoped to exactly the two stale status lines in WORKSHOP_STRUCTURE.md -- no unintended changes

Closes #27