### PR TITLE
chore: fix stale package.json metadata for multi-workshop site

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "master-virtual-meetings-workshop",
+  "name": "roberto-ferraro-workshops",
   "version": "1.0.0",
-  "description": "Landing page for Roberto Ferraro's Master Virtual Meetings workshop",
+  "description": "Multi-workshop landing site for Roberto Ferraro's professional-development workshops",
   "main": "index.html",
   "scripts": {
     "start": "python -m http.server 8000",
@@ -13,8 +13,7 @@
   "keywords": [
     "workshop",
     "landing-page",
-    "virtual-meetings",
-    "communication",
+    "professional-development",
     "roberto-ferraro"
   ],
   "author": "Roberto Ferraro",
@@ -27,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/robertoferraro/notion-automation.git"
+    "url": "https://github.com/ferraroroberto/website.git"
   },
-  "homepage": "https://www.robertoferraro.net/virtual-communication"
+  "homepage": "https://www.robertoferraro.net/workshops"
 } 


### PR DESCRIPTION
## Summary

- Fixes `repository.url` which pointed at an unrelated repo (`robertoferraro/notion-automation`) — now correctly points at `ferraroroberto/website`
- Fixes `homepage` from the single-workshop URL (`/virtual-communication`) to the index URL (`/workshops`), matching `index.html`'s own `og:url`
- Updates `name` and `description` (and removes single-workshop `keywords`) to reflect that this is now a multi-workshop site

All three items were surfaced by `/codebase-audit` (issue #23). None of these fields affect the deployed static site at runtime — `package.json` is not read by any HTML/JS/CSS — but the wrong `repository.url` is the most material: it sends tooling and readers to an unrelated project.

## Validation

- 3b: `python -c "import json; json.load(open('package.json'))"` — valid JSON
- 3e: Grepped all `.html`/`.js`/`.css` for `package.json`/`repository.url`/`homepage` — no runtime references; confirmed this is npm-tooling metadata only
- 3f: `git diff` — only `package.json` touched, exactly the five fields specified in the issue
- Confirmed `gh repo view` reports `ferraroroberto/website` — matches the new `repository.url`
- Confirmed `index.html:8` `og:url` is already `https://www.robertoferraro.net/workshops` — `homepage` now aligned

Closes #23