### PR TITLE
chore: fix stale workshop-config.js comment refs in workshops-index-config.js

### DIFF
--- a/config/workshops-index-config.js
+++ b/config/workshops-index-config.js
@@ -4,7 +4,7 @@
 // Title, subtitle, and date are derived from the per-workshop config globals
 // (loaded before this file in index.html via workshop-base.js and the three
 // per-workshop configs). This makes those fields a single source of truth:
-// editing config/workshop-config.js (or its siblings) automatically updates
+// editing config/virtual-communication-config.js (or its siblings) automatically updates
 // what the index card shows, with no second copy to drift.
 //
 // Fields that are index-specific summaries with no direct equivalent in the
@@ -23,7 +23,7 @@ const WORKSHOPS_INDEX_CONFIG = {
         {
             id: 'virtual-communication',
             slug: 'virtual-communication',
-            // Derived from config/workshop-config.js — single source of truth.
+            // Derived from config/virtual-communication-config.js — single source of truth.
             title: _field(window.WORKSHOP_CONFIG_VIRTUAL_COMMUNICATION, 'title',
                 'Master Virtual Meetings: From Boring to Brilliant & Fun'),
             subtitle: _field(window.WORKSHOP_CONFIG_VIRTUAL_COMMUNICATION, 'subtitle',


### PR DESCRIPTION
## Summary

- Fix two comments in `config/workshops-index-config.js` that still named `config/workshop-config.js` — a file that no longer exists after it was renamed to `config/virtual-communication-config.js` in commit `02fe156`.
- Line 7: block-level comment updated to reference `virtual-communication-config.js`.
- Line 26: inline `// Derived from …` comment updated to reference `virtual-communication-config.js`.

## Validation

- `node --check config/workshops-index-config.js` — syntax OK.
- `git diff HEAD` reviewed: exactly 2 comment-only lines changed in 1 file, no logic altered.
- No `.github/workflows/` exists in this repo — no CI to wait for.

Closes #34