### PR TITLE
chore: remove redundant pricing block from virtual-communication-config.js

### DIFF
--- a/config/virtual-communication-config.js
+++ b/config/virtual-communication-config.js
@@ -34,25 +34,6 @@ const WORKSHOP_CONFIG = createWorkshopConfig({
     videoId: 'ojPvNyMOFZg',
     videoUrl: 'https://www.youtube.com/embed/ojPvNyMOFZg',
 
-    // Pricing — base tiers, with workshop-specific recording/coaching extras
-    pricing: {
-        recording: {
-            features: [
-                'Everything in Access to Live Session',
-                'Become a workshop patron',
-                'Session recording',
-                'Action guide with key highlights'
-            ]
-        },
-        coaching: {
-            features: [
-                'Everything in Recording package',
-                '45 minutes personal coaching session',
-                'Personalized feedback'
-            ]
-        }
-    },
-
     // SEO
     meta: {
         title: 'Master Virtual Meetings Workshop - Roberto Ferraro',


### PR DESCRIPTION
## Summary

- Deleted the `pricing.recording.features` and `pricing.coaching.features` override arrays from `config/virtual-communication-config.js` (lines 37-54 of the original file).
- These arrays were byte-for-byte identical to the defaults declared in `config/workshop-base.js`; the `createWorkshopConfig()` deep-merge already inherits them verbatim.
- Keeping them contradicted the file's own header comment ("Only the values that differ from config/workshop-base.js are listed here") and misled future editors into thinking the values were workshop-specific.

## Validation

- **Byte-for-byte equality check (pre-deletion):** `recording.features` and `coaching.features` in the override matched the base strings exactly — confirmed by manual read of both files.
- **Syntax gate:** `node --check config/workshop-base.js && node --check config/virtual-communication-config.js` — PASS.
- **Behavioral proof:** Node probe ran `createWorkshopConfig()` both with and without the now-deleted pricing block; `JSON.stringify(before.pricing) === JSON.stringify(after.pricing)` — PASS. Full pricing output logged and verified.
- **Diff sanity:** `git diff main...HEAD` shows exactly the 19-line deletion, nothing else.
- **CI:** no GitHub Actions workflows exist in this repo — CI wait skipped.

Closes #36