### PR TITLE
docs: fix three doc-accuracy gaps (redirect shims, shim template, design-system palette)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ A multi-workshop landing site for Roberto Ferraro's professional-development wor
 - Every per-workshop config **calls `createWorkshopConfig()`** from `config/workshop-base.js`; don't hand-roll a config object.
 - Data files export via **`exposeData(name, value)`** from `data/_export.js` — preserve the dual `window` / `module.exports` export.
 - **Progressive enhancement:** HTML ships `href="#"` / placeholder fallbacks; JS populates real content and CTA hrefs (`buildLumaUrl()`). The page must degrade gracefully if JS fails.
-- **All paths relative** (Netlify hosting + iframe embedding). Mobile-first; design system is black/white with yellow accent `#FFCC00`, Poppins for headers.
+- **All paths relative** (Netlify hosting + iframe embedding). Mobile-first; workshop pages use black/white with yellow accent `#FFCC00`, Poppins for headers. The workshop index uses per-workshop accent gradients (blue/red/green) — see `css/workshop-index.css`.
 - **Adding a workshop:** follow the step-by-step guide in `WORKSHOP_STRUCTURE.md` (new config + data files + redirect shim, then link from the index).
 
 ## Running locally

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ website/
 - **Per-workshop configs** (`config/<slug>-config.js`): Override title, dates, pricing, video ID, SEO meta — call `createWorkshopConfig()` from the shared base
 - **Shared base** (`config/workshop-base.js`): `buildLumaUrl()` helper + `createWorkshopConfig()` factory used by every per-workshop config
 - **Data files** (`data/<slug>-testimonials.js`, `data/<slug>-benefits.js`): Content separated by type for easy maintenance
-- **Redirect shims** (`virtual-communication.html`, etc.): Zero-content files that immediately `location.replace` to the template URL — keep old URLs working
+- **Redirect shims** (`virtual-communication.html`, etc.): Thin redirect shims that carry per-page SEO meta (canonical + Open Graph + Twitter tags, `http-equiv="refresh"` fallback, and a "Continue" link) and immediately `location.replace` to the template URL — keep old URLs working
 
 ### JavaScript Roles
 - **`js/main.js`**: Populates the workshop template with title, subtitle, dates, pricing, benefits, testimonials, and illustrations; sets CTA button `href` via `buildLumaUrl()` — HTML uses `href="#"` as a no-JS fallback only
@@ -68,7 +68,7 @@ website/
 ## Key Features
 
 ### Design System
-- **Color Scheme**: Black/white with yellow accent (#FFCC00)
+- **Color Scheme**: Black/white with yellow accent (#FFCC00) for workshop pages. The workshop index uses per-workshop accent gradients (blue for Virtual Communication, red/orange for Personal Branding, green for Digital Leadership) — see `css/workshop-index.css` and the "Color Schemes" section in WORKSHOP_STRUCTURE.md
 - **Typography**: Poppins for headers, system fonts for body
 - **Layout**: CSS Grid and Flexbox for responsive design
 - **Mobile-First**: Responsive design with mobile breakpoints

--- a/WORKSHOP_STRUCTURE.md
+++ b/WORKSHOP_STRUCTURE.md
@@ -92,13 +92,39 @@ Add the slug and its three script paths to the `WORKSHOPS` map inside `workshop.
 ```
 
 ### 4. Add a redirect shim
-Create `new-workshop.html` for backward-compatible URLs:
+Create `new-workshop.html` for backward-compatible URLs. Include the full SEO `<head>` so link previews and search indexing work on the short URL before the redirect fires — omitting it loses the per-page Open Graph/Twitter meta that the shipped shims carry:
 
 ```html
 <!DOCTYPE html>
-<html><head><meta charset="UTF-8">
-<script>window.location.replace('workshop.html?w=new-workshop');</script>
-</head><body></body></html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="index, follow">
+    <title>Your Workshop Title - Roberto Ferraro</title>
+    <meta name="description" content="Your workshop description for SEO.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://www.robertoferraro.net/new-workshop">
+    <meta property="og:title" content="Your Workshop Title - Roberto Ferraro">
+    <meta property="og:description" content="Your workshop description for social sharing.">
+    <meta property="og:image" content="https://www.robertoferraro.net/images/new-workshop-preview.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Your Workshop Title - Roberto Ferraro">
+    <meta name="twitter:description" content="Your workshop description for social sharing.">
+    <meta name="twitter:image" content="https://www.robertoferraro.net/images/new-workshop-preview.jpg">
+    <link rel="canonical" href="workshop.html?w=new-workshop">
+    <!--
+      Redirect shim: keeps the short URL working and redirects to the template.
+      The SEO <head> above ensures link previews and search indexing work on
+      the canonical URL before the redirect fires.
+    -->
+    <meta http-equiv="refresh" content="0; url=workshop.html?w=new-workshop">
+    <script>window.location.replace('workshop.html?w=new-workshop');</script>
+</head>
+<body>
+    <p>Redirecting to the workshop page&hellip; <a href="workshop.html?w=new-workshop">Continue</a>.</p>
+</body>
+</html>
 ```
 
 ### 5. Update Workshop Index Configuration


### PR DESCRIPTION
## Summary

- **README.md line 60**: redirect shims were described as "zero-content" but each shipped shim carries ~30 lines of SEO `<head>` (canonical, Open Graph, Twitter meta, `http-equiv="refresh"` fallback, visible "Continue" link); reworded to match reality so nobody trims them to true zero-content and loses the SEO block
- **WORKSHOP_STRUCTURE.md Step 4**: the "add a redirect shim" template was a bare 4-liner, diverging from every existing shipped shim; updated to the full SEO `<head>` shape with a note explaining why omitting it costs the per-page OG/Twitter meta
- **README.md Design System + CLAUDE.md**: both stated the design system as "black/white with yellow accent (#FFCC00)" with no qualification — contradicted by the workshop index which intentionally uses per-workshop blue/red/green gradients; clarified that the yellow-accent system applies to workshop pages, with a pointer to `css/workshop-index.css` and the "Color Schemes" section in WORKSHOP_STRUCTURE.md

## Validation

- 3b Syntax gate: static site (HTML/CSS/JS only), no compile step — N/A
- 3c Unit tests: none exist for this repo — N/A
- 3d E2E gate: no `verify-before-ship` script — N/A
- 3e Behavioural: docs-only change, no code paths touched; conformance confirmed by reading the actual shipped shims against the updated text
- 3f Sanity sweep: `git diff main...HEAD` — exactly 3 files changed (README.md, WORKSHOP_STRUCTURE.md, CLAUDE.md), all within stated scope, no deps/tests/gitignore touched
- 3g Senior-dev check: all three accuracy gaps fixed, template now matches shipped shims, no regressions possible on a static-site doc edit

Closes #44