### PR TITLE
fix: eliminate WORKSHOP_CONFIG const collision via IIFE wrappers

### DIFF
--- a/WORKSHOP_STRUCTURE.md
+++ b/WORKSHOP_STRUCTURE.md
@@ -44,6 +44,10 @@ Create `config/new-workshop-config.js` using `createWorkshopConfig()` from the b
 
 ```javascript
 // config/new-workshop-config.js
+// Wrap in an IIFE so the local `const WORKSHOP_CONFIG` is scoped here and does
+// not collide with the same declaration in the other per-workshop config files
+// that index.html loads back-to-back in the same page scope.
+(function () {
 const WORKSHOP_CONFIG = createWorkshopConfig({
     eventId: 'your-event-id',
     eventUrl: 'https://luma.com/your-event-id',
@@ -68,6 +72,7 @@ if (typeof window !== 'undefined') {
     // Slug converted to UPPER_CASE: e.g. 'new-workshop' → WORKSHOP_CONFIG_NEW_WORKSHOP.
     window.WORKSHOP_CONFIG_NEW_WORKSHOP = WORKSHOP_CONFIG;
 }
+})();
 ```
 
 ### 2. Create data files
@@ -137,7 +142,9 @@ Two edits are required: **index.html** and **workshops-index-config.js**.
 <script src="config/workshops-index-config.js"></script>  <!-- already there -->
 ```
 
-**5b. Add the workshop entry to `config/workshops-index-config.js`**. The `title`, `subtitle`, and `date` fields are derived automatically from the named global you set in Step 1 via the `_field()` helper — do not duplicate them here. Only index-specific fields (`description`, `features`, `price`, `ctaText`, `ctaUrl`, `colorScheme`, `status`) belong in this entry:
+> **Important — IIFE required.** `index.html` loads all per-workshop config files back-to-back as classic `<script>` tags in the same page scope. Each file declares a local `const WORKSHOP_CONFIG`; without an IIFE wrapper the 2nd and 3rd `const` throw `SyntaxError: Identifier 'WORKSHOP_CONFIG' has already been declared`, leaving their `window.WORKSHOP_CONFIG_*` globals undefined. The template in Step 1 already uses an IIFE — keep it when copying to your new config file.
+
+**5b. Add the workshop entry to `config/workshops-index-config.js`**. The `title`, `subtitle`, and `date` fields are derived automatically from the named global you set in Step 1 via the `_field()` helper — do not duplicate them here. Only index-specific fields (`description`, `features`, `price`, `ctaText`, `ctaUrl`, `colorScheme`, `status`) belong in this entry. (The `_field()` derivation relies on `window.WORKSHOP_CONFIG_NEW_WORKSHOP` being defined — which only works if the config file uses the IIFE wrapper described in Step 5a above.)
 
 ```javascript
 {

--- a/config/digital-leadership-config.js
+++ b/config/digital-leadership-config.js
@@ -1,6 +1,7 @@
 // Digital Leadership Workshop Configuration
 // Only the values that differ from config/workshop-base.js are listed here.
 
+(function () {
 const WORKSHOP_CONFIG = createWorkshopConfig({
     // Event Details
     eventId: 'digital-leadership-demo',
@@ -72,3 +73,4 @@ if (typeof window !== 'undefined') {
     // Named export for the workshop index (single source of truth for shared fields).
     window.WORKSHOP_CONFIG_DIGITAL_LEADERSHIP = WORKSHOP_CONFIG;
 }
+})();

--- a/config/personal-branding-config.js
+++ b/config/personal-branding-config.js
@@ -1,6 +1,7 @@
 // Personal Branding Workshop Configuration
 // Only the values that differ from config/workshop-base.js are listed here.
 
+(function () {
 const WORKSHOP_CONFIG = createWorkshopConfig({
     // Event Details
     eventId: 'personal-branding-demo',
@@ -72,3 +73,4 @@ if (typeof window !== 'undefined') {
     // Named export for the workshop index (single source of truth for shared fields).
     window.WORKSHOP_CONFIG_PERSONAL_BRANDING = WORKSHOP_CONFIG;
 }
+})();

--- a/config/virtual-communication-config.js
+++ b/config/virtual-communication-config.js
@@ -1,6 +1,7 @@
 // Virtual Communication Workshop Configuration
 // Only the values that differ from config/workshop-base.js are listed here.
 
+(function () {
 const WORKSHOP_CONFIG = createWorkshopConfig({
     // Event Details
     eventId: 'neemuhqj',
@@ -53,3 +54,4 @@ if (typeof window !== 'undefined') {
     // Named export for the workshop index (single source of truth for shared fields).
     window.WORKSHOP_CONFIG_VIRTUAL_COMMUNICATION = WORKSHOP_CONFIG;
 }
+})();


### PR DESCRIPTION
## Summary

- Three per-workshop config files (`virtual-communication-config.js`, `personal-branding-config.js`, `digital-leadership-config.js`) each declared a top-level `const WORKSHOP_CONFIG` in classic `<script>` tags, all sharing one lexical environment on `index.html`. The 2nd and 3rd declarations threw `SyntaxError: Identifier 'WORKSHOP_CONFIG' has already been declared` at parse time, leaving `window.WORKSHOP_CONFIG_PERSONAL_BRANDING` and `window.WORKSHOP_CONFIG_DIGITAL_LEADERSHIP` undefined -- silently breaking the single-source-of-truth derivation in `workshops-index-config.js` for 2 of 3 cards.
- Wrapped each config file body in an IIFE so the local `const` is scoped within the IIFE and all three can co-load without collision. Named `window.WORKSHOP_CONFIG_*` globals are still assigned inside each IIFE.
- Updated `WORKSHOP_STRUCTURE.md` Step 1 template (IIFE added), Step 5a (explicit "IIFE required" warning callout), and Step 5b (noted `_field()` depends on the named global being defined).

## Validation

- **Syntax gate:** `node --check` on all three edited config files -- no errors.
- **Reproduction proof:** Node simulation loading all three IIFE-wrapped configs in sequence -> `WORKSHOP_CONFIG_VIRTUAL_COMMUNICATION`, `WORKSHOP_CONFIG_PERSONAL_BRANDING`, `WORKSHOP_CONFIG_DIGITAL_LEADERSHIP` all defined with correct titles. Exit 0.
- **Before proof:** `new Function("const WORKSHOP_CONFIG={a:1}; const WORKSHOP_CONFIG={b:2};")()` -> `SyntaxError: Identifier 'WORKSHOP_CONFIG' has already been declared`. Confirmed old pattern was broken.
- **Diff scope:** only the three config files and `WORKSHOP_STRUCTURE.md` changed -- no unintended edits, no removed tests, no dependency changes.

Closes #42