### PR TITLE
fix: address workshop audit findings

### DIFF
--- a/config/digital-leadership-config.js
+++ b/config/digital-leadership-config.js
@@ -4,8 +4,8 @@
 (function () {
 const WORKSHOP_CONFIG = createWorkshopConfig({
     // Event Details
-    eventId: 'digital-leadership-demo',
-    eventUrl: 'https://lu.ma/digital-leadership-demo',
+    status: 'coming-soon',
+    comingSoonMessage: 'This workshop is being prepared. Check back soon for dates, pricing, and registration details.',
 
     // UTM campaign (source/medium come from the base)
     utmParams: {
@@ -32,8 +32,8 @@ const WORKSHOP_CONFIG = createWorkshopConfig({
     },
 
     // Video
-    videoId: 'demo-video-id',
-    videoUrl: 'https://www.youtube.com/embed/demo-video-id',
+    videoId: '',
+    videoUrl: '',
 
     // Pricing — base tiers, with workshop-specific recording/coaching extras
     pricing: {
@@ -62,7 +62,7 @@ const WORKSHOP_CONFIG = createWorkshopConfig({
         ogDescription: 'Develop the essential leadership skills needed to inspire, motivate, and guide teams effectively in virtual and hybrid work environments.',
         ogType: 'website',
         ogUrl: 'https://www.robertoferraro.net/digital-leadership',
-        ogImage: 'https://www.robertoferraro.net/images/digital-leadership-preview.jpg',
+        ogImage: 'https://www.robertoferraro.net/images/group.png',
         twitterCard: 'summary_large_image'
     }
 });

--- a/config/personal-branding-config.js
+++ b/config/personal-branding-config.js
@@ -4,8 +4,8 @@
 (function () {
 const WORKSHOP_CONFIG = createWorkshopConfig({
     // Event Details
-    eventId: 'personal-branding-demo',
-    eventUrl: 'https://lu.ma/personal-branding-demo',
+    status: 'coming-soon',
+    comingSoonMessage: 'This workshop is being prepared. Check back soon for dates, pricing, and registration details.',
 
     // UTM campaign (source/medium come from the base)
     utmParams: {
@@ -32,8 +32,8 @@ const WORKSHOP_CONFIG = createWorkshopConfig({
     },
 
     // Video
-    videoId: 'demo-video-id',
-    videoUrl: 'https://www.youtube.com/embed/demo-video-id',
+    videoId: '',
+    videoUrl: '',
 
     // Pricing — base tiers, with workshop-specific recording/coaching extras
     pricing: {
@@ -62,7 +62,7 @@ const WORKSHOP_CONFIG = createWorkshopConfig({
         ogDescription: 'Discover how to build a powerful personal brand that authentically represents you and helps you achieve your professional goals.',
         ogType: 'website',
         ogUrl: 'https://www.robertoferraro.net/personal-branding',
-        ogImage: 'https://www.robertoferraro.net/images/personal-branding-preview.jpg',
+        ogImage: 'https://www.robertoferraro.net/images/group.png',
         twitterCard: 'summary_large_image'
     }
 });

--- a/config/virtual-communication-config.js
+++ b/config/virtual-communication-config.js
@@ -43,7 +43,7 @@ const WORKSHOP_CONFIG = createWorkshopConfig({
         ogDescription: 'Learn to communicate effectively in virtual settings with practical tools you can use right away.',
         ogType: 'website',
         ogUrl: 'https://www.robertoferraro.net/virtual-communication',
-        ogImage: 'https://www.robertoferraro.net/images/virtual-communication-preview.jpg',
+        ogImage: 'https://www.robertoferraro.net/images/group.png',
         twitterCard: 'summary_large_image'
     }
 });

--- a/css/styles.css
+++ b/css/styles.css
@@ -103,6 +103,10 @@ body {
     border: none;
 }
 
+.video-container[hidden] {
+    display: none;
+}
+
 /* ===== BENEFITS SECTION ===== */
 .benefits-section {
     background-color: #f2f2f2;
@@ -296,6 +300,22 @@ body {
     transition: transform 0.3s ease;
 }
 
+.coming-soon-notice {
+    grid-column: 1 / -1;
+    max-width: 640px;
+    margin: 0 auto;
+    background: white;
+    color: #1a1a1a;
+    padding: 40px 30px;
+    border-radius: 12px;
+    text-align: center;
+}
+
+.coming-soon-notice h3 {
+    font-size: 1.3em;
+    margin-bottom: 10px;
+}
+
 .pricing-card:hover {
     transform: translateY(-5px);
 }
@@ -377,6 +397,13 @@ body {
 .cta-button:hover {
     background: #FFCC00;
     color: #1a1a1a;
+}
+
+.cta-button.is-disabled,
+.cta-button.is-disabled:hover {
+    background: #8c8c8c;
+    color: white;
+    cursor: not-allowed;
 }
 
 .pricing-card:not(.featured) .cta-button:hover {
@@ -478,4 +505,4 @@ body {
         padding-left: 20px;
         padding-right: 20px;
     }
-} 
+}

--- a/digital-leadership.html
+++ b/digital-leadership.html
@@ -10,11 +10,11 @@
     <meta property="og:url" content="https://www.robertoferraro.net/digital-leadership">
     <meta property="og:title" content="Digital Leadership: Lead with Impact in the Virtual World - Roberto Ferraro">
     <meta property="og:description" content="Develop the essential leadership skills needed to inspire, motivate, and guide teams effectively in virtual and hybrid work environments.">
-    <meta property="og:image" content="https://www.robertoferraro.net/images/digital-leadership-preview.jpg">
+    <meta property="og:image" content="https://www.robertoferraro.net/images/group.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Digital Leadership: Lead with Impact in the Virtual World - Roberto Ferraro">
     <meta name="twitter:description" content="Develop the essential leadership skills needed to inspire, motivate, and guide teams effectively in virtual and hybrid work environments.">
-    <meta name="twitter:image" content="https://www.robertoferraro.net/images/digital-leadership-preview.jpg">
+    <meta name="twitter:image" content="https://www.robertoferraro.net/images/group.png">
     <link rel="canonical" href="workshop.html?w=digital-leadership">
     <!--
       All three workshop pages are now driven by the single workshop.html

--- a/index.html
+++ b/index.html
@@ -6,11 +6,11 @@
     <meta name="robots" content="index, follow">
     <meta name="theme-color" content="#0077b5">
     <meta property="og:url" content="https://www.robertoferraro.net/workshops">
-    <meta property="og:image" content="https://www.robertoferraro.net/images/workshop-preview.jpg">
+    <meta property="og:image" content="https://www.robertoferraro.net/images/group.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Professional Workshops - Roberto Ferraro">
     <meta name="twitter:description" content="Interactive workshops to enhance your virtual communication, personal branding, and digital leadership skills.">
-    <meta name="twitter:image" content="https://www.robertoferraro.net/images/workshop-preview.jpg">
+    <meta name="twitter:image" content="https://www.robertoferraro.net/images/group.png">
     <title>Workshops - Roberto Ferraro</title>
     <meta name="description" content="Transform your professional skills with Roberto Ferraro's interactive workshops. Master virtual communication, personal branding, and digital leadership.">
     <meta property="og:title" content="Professional Workshops - Roberto Ferraro">
@@ -36,7 +36,7 @@
             <p>All workshops are designed to be practical, engaging, and immediately applicable to your professional life.</p>
         </footer>
     </div>
-    
+
     <script src="config/workshop-base.js"></script>
     <script src="config/virtual-communication-config.js"></script>
     <script src="config/personal-branding-config.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -52,13 +52,7 @@ function populateWorkshopDetails() {
         if (durationElement) durationElement.textContent = config.duration;
         if (formatElement) formatElement.textContent = config.format;
         
-        // Update all CTA buttons with the correct event URL
-        document.querySelectorAll('.cta-button').forEach(button => {
-            const urlWithUtm = window.buildLumaUrl();
-            button.href = urlWithUtm;
-            button.target = '_blank';
-            button.rel = 'noopener noreferrer';
-        });
+        updateCtaButtons(config);
     }
 }
 
@@ -134,6 +128,11 @@ function populateCopy() {
         const textEl = document.getElementById('final-cta-text');
         if (headingEl && config.finalCta.heading) headingEl.textContent = config.finalCta.heading;
         if (textEl && config.finalCta.text) textEl.innerHTML = config.finalCta.text;
+    }
+
+    const availabilityEl = document.getElementById('final-cta-availability');
+    if (availabilityEl && !isBookingOpen(config)) {
+        availabilityEl.textContent = config.comingSoonMessage || 'Registration details will be published here soon.';
     }
 }
 
@@ -212,6 +211,19 @@ function populatePricing() {
         if (pricingContainer) {
             const pricing = window.WORKSHOP_CONFIG.pricing;
             const config = window.WORKSHOP_CONFIG;
+
+            if (!isBookingOpen(config)) {
+                const pricingTitle = document.querySelector('.pricing-title');
+                if (pricingTitle) pricingTitle.textContent = 'Registration Opens Soon';
+                pricingContainer.innerHTML = `
+                <div class="coming-soon-notice">
+                    <h3>Coming Soon</h3>
+                    <p>${config.comingSoonMessage || 'This workshop is being prepared. Check back soon for registration details.'}</p>
+                </div>
+            `;
+                updateCtaButtons(config);
+                return;
+            }
             
             pricingContainer.innerHTML = Object.values(pricing).map(plan => `
                 <div class="pricing-card ${plan.featured ? 'featured' : ''}">
@@ -231,6 +243,7 @@ function populatePricing() {
                     </a>
                 </div>
             `).join('');
+            updateCtaButtons(config);
         }
     }
 }
@@ -238,8 +251,40 @@ function populatePricing() {
 function populateVideo() {
     if (window.WORKSHOP_CONFIG) {
         const videoElement = document.getElementById('workshop-video');
-        if (videoElement) {
-            videoElement.src = window.WORKSHOP_CONFIG.videoUrl;
+        const videoContainer = videoElement ? videoElement.closest('.video-container') : null;
+        const videoUrl = window.WORKSHOP_CONFIG.videoUrl;
+        if (videoElement && videoUrl) {
+            videoElement.src = videoUrl;
+            if (videoContainer) videoContainer.hidden = false;
+        } else if (videoContainer) {
+            videoContainer.hidden = true;
         }
     }
-} 
+}
+
+function isBookingOpen(config) {
+    return config && config.status !== 'coming-soon' && Boolean(window.buildLumaUrl(config));
+}
+
+function updateCtaButtons(config) {
+    const bookingUrl = window.buildLumaUrl(config);
+    const bookingOpen = isBookingOpen(config);
+
+    document.querySelectorAll('.cta-button').forEach(button => {
+        if (bookingOpen) {
+            button.href = bookingUrl;
+            button.target = '_blank';
+            button.rel = 'noopener noreferrer';
+            button.removeAttribute('aria-disabled');
+            button.classList.remove('is-disabled');
+            return;
+        }
+
+        button.removeAttribute('href');
+        button.removeAttribute('target');
+        button.removeAttribute('rel');
+        button.setAttribute('aria-disabled', 'true');
+        button.classList.add('is-disabled');
+        button.textContent = 'Coming Soon';
+    });
+}

--- a/personal-branding.html
+++ b/personal-branding.html
@@ -10,11 +10,11 @@
     <meta property="og:url" content="https://www.robertoferraro.net/personal-branding">
     <meta property="og:title" content="Build Your Personal Brand: Stand Out in the Digital Age - Roberto Ferraro">
     <meta property="og:description" content="Discover how to build a powerful personal brand that authentically represents you and helps you achieve your professional goals.">
-    <meta property="og:image" content="https://www.robertoferraro.net/images/personal-branding-preview.jpg">
+    <meta property="og:image" content="https://www.robertoferraro.net/images/group.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Build Your Personal Brand: Stand Out in the Digital Age - Roberto Ferraro">
     <meta name="twitter:description" content="Discover how to build a powerful personal brand that authentically represents you and helps you achieve your professional goals.">
-    <meta name="twitter:image" content="https://www.robertoferraro.net/images/personal-branding-preview.jpg">
+    <meta name="twitter:image" content="https://www.robertoferraro.net/images/group.png">
     <link rel="canonical" href="workshop.html?w=personal-branding">
     <!--
       All three workshop pages are now driven by the single workshop.html

--- a/virtual-communication.html
+++ b/virtual-communication.html
@@ -10,11 +10,11 @@
     <meta property="og:url" content="https://www.robertoferraro.net/virtual-communication">
     <meta property="og:title" content="Master Virtual Meetings: From Boring to Brilliant - Roberto Ferraro">
     <meta property="og:description" content="Learn to communicate effectively in virtual settings with practical tools you can use right away.">
-    <meta property="og:image" content="https://www.robertoferraro.net/images/virtual-communication-preview.jpg">
+    <meta property="og:image" content="https://www.robertoferraro.net/images/group.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Master Virtual Meetings: From Boring to Brilliant - Roberto Ferraro">
     <meta name="twitter:description" content="Learn to communicate effectively in virtual settings with practical tools you can use right away.">
-    <meta name="twitter:image" content="https://www.robertoferraro.net/images/virtual-communication-preview.jpg">
+    <meta name="twitter:image" content="https://www.robertoferraro.net/images/group.png">
     <link rel="canonical" href="workshop.html?w=virtual-communication">
     <!--
       All three workshop pages are now driven by the single workshop.html

--- a/workshop.html
+++ b/workshop.html
@@ -132,7 +132,7 @@
         <div class="final-cta">
             <h2 id="final-cta-heading"></h2>
             <p id="final-cta-text"></p>
-            <p><strong>Limited spots available for better interaction!</strong></p>
+            <p><strong id="final-cta-availability">Limited spots available for better interaction!</strong></p>
             <a
               href="#"
               class="cta-button"


### PR DESCRIPTION
## Summary
- Point social preview metadata at an existing tracked image (was referencing untracked *-preview.jpg assets)
- Disable placeholder booking/video resources for coming-soon workshops (digital-leadership, personal-branding) so direct visitors don't hit lu.ma demo links or a fake video id

## Test plan
- [x] Confirmed `images/group.png` (the new shared preview image) exists in the tree
- [x] No test suite for this static site — manual review of the diff against the 6 audit findings

Closes #48