### PR TITLE
chore: remove dead CommonJS export scaffolding in data/config files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ A multi-workshop landing site for Roberto Ferraro's professional-development wor
   - `<slug>-config.js` — per-workshop overrides (event ID, title, dates, pricing, video, SEO meta); each calls `createWorkshopConfig()`.
   - `workshops-index-config.js` — index page config.
 - `data/`
-  - `_export.js` — `exposeData(name, value)` helper (sets both `window[name]` and `module.exports`).
+  - `_export.js` — `exposeData(name, value)` helper (sets `window[name]`; browser-only, no CommonJS/`module.exports` path).
   - `<slug>-testimonials.js`, `<slug>-benefits.js` — per-workshop content; `illustrations.js` is shared.
 - `js/` — `main.js` (populates the template), `workshop-index.js`, `iframe-resize.js` (`sendHeight()` postMessage for Squarespace embedding), `linkedin-fix.js` (opens CTAs in the system browser from LinkedIn/WebView).
 
@@ -30,7 +30,7 @@ A multi-workshop landing site for Roberto Ferraro's professional-development wor
 
 - **Data-driven, no HTML edits for content.** To change a workshop, edit `config/<slug>-config.js` and `data/<slug>-*.js` — `workshop.html` is a template and stays untouched.
 - Every per-workshop config **calls `createWorkshopConfig()`** from `config/workshop-base.js`; don't hand-roll a config object.
-- Data files export via **`exposeData(name, value)`** from `data/_export.js` — preserve the dual `window` / `module.exports` export.
+- Data files export via **`exposeData(name, value)`** from `data/_export.js` — sets `window[name]` only; there is no CommonJS export path, so don't add a `require()`-based consumer without first making `_export.js` support it for real.
 - **Progressive enhancement:** HTML ships `href="#"` / placeholder fallbacks; JS populates real content and CTA hrefs (`buildLumaUrl()`). The page must degrade gracefully if JS fails.
 - **All paths relative** (Netlify hosting + iframe embedding). Mobile-first; workshop pages use black/white with yellow accent `#FFCC00`, Poppins for headers. The workshop index uses per-workshop accent gradients (blue/red/green) — see `css/workshop-index.css`.
 - **Adding a workshop:** follow the step-by-step guide in `WORKSHOP_STRUCTURE.md` (new config + data files + redirect shim, then link from the index).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ website/
 │   ├── digital-leadership-config.js   # Digital Leadership per-workshop config
 │   └── workshops-index-config.js      # Workshop index page config
 ├── data/
-│   ├── _export.js                     # Shared exposeData() helper (window + module.exports)
+│   ├── _export.js                     # Shared exposeData() helper (window, browser-only)
 │   ├── virtual-communication-testimonials.js # Virtual Communication testimonials
 │   ├── virtual-communication-benefits.js    # Virtual Communication benefits
 │   ├── personal-branding-testimonials.js
@@ -90,7 +90,7 @@ See [WORKSHOP_STRUCTURE.md](WORKSHOP_STRUCTURE.md) for the complete annotated fi
 
 - **`config/workshop-base.js`** — shared factory; every per-workshop config calls `createWorkshopConfig()` from here
 - **`config/<slug>-config.js`** — per-workshop overrides (event ID, title, dates, pricing, video, SEO meta)
-- **`data/_export.js`** — `exposeData(name, value)` helper that sets both `window[name]` and `module.exports`
+- **`data/_export.js`** — `exposeData(name, value)` helper that sets `window[name]` (browser-only; no CommonJS/`module.exports` path — nothing requires these files directly)
 - **`data/illustrations.js`** — shared across all workshops; per-workshop data files follow `<slug>-testimonials.js` / `<slug>-benefits.js` naming
 
 ## Maintenance Guide

--- a/WORKSHOP_STRUCTURE.md
+++ b/WORKSHOP_STRUCTURE.md
@@ -19,7 +19,7 @@ This website supports multiple workshops driven by a single template page (`work
 - `config/digital-leadership-config.js` - Digital Leadership per-workshop overrides
 
 ### Data Files
-- `data/_export.js` - **Shared export helper**: `exposeData(name, value)` — sets `window[name]` and `module.exports` in one call
+- `data/_export.js` - **Shared export helper**: `exposeData(name, value)` — sets `window[name]` (browser-only; no `module.exports`/CommonJS path)
 - `data/virtual-communication-benefits.js` - Benefits for Virtual Communication workshop
 - `data/virtual-communication-testimonials.js` - Testimonials for Virtual Communication workshop
 - `data/personal-branding-benefits.js` - Benefits for Personal Branding workshop

--- a/config/workshops-index-config.js
+++ b/config/workshops-index-config.js
@@ -12,7 +12,8 @@
 // remain here.
 
 // Derive a field from a per-workshop config global; fall back to the default
-// if the config global isn't available (e.g. standalone Node.js requires).
+// if the per-workshop config script hasn't loaded (e.g. wrong script order,
+// or the file missing during local preview).
 function _field(config, key, fallback) {
     return (config && config[key] !== undefined) ? config[key] : fallback;
 }
@@ -107,11 +108,6 @@ const WORKSHOPS_INDEX_CONFIG = {
         ogType: 'website'
     }
 };
-
-// Export for use in other files (if using modules)
-if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { WORKSHOPS_INDEX_CONFIG };
-}
 
 // Make available globally for inline use
 window.WORKSHOPS_INDEX_CONFIG = WORKSHOPS_INDEX_CONFIG;

--- a/data/_export.js
+++ b/data/_export.js
@@ -1,24 +1,24 @@
 // Shared data exporter
-// Collapses the repeated "module.exports = X; window.X = X;" tail that every
-// data file used to carry. Each data file ends with a single exposeData() call.
+// Collapses the repeated "window.X = X;" tail that every data file used to
+// carry. Each data file ends with a single exposeData() call.
+//
+// Browser-only: the site ships no build step, and nothing requires() these
+// files directly (production path is <script src> in workshop.html). A
+// prior version also stubbed a CommonJS `module.exports = value` branch to
+// promise dual browser/CommonJS support, but it was dead: exposeData()
+// closes over *this* file's own `module`, so `module.exports = value` could
+// never reach a data file's own module.exports — requiring a data file
+// always returned `{}`. Removed rather than "fixed" since nothing consumes it.
 //
 // Load order: this file must be included before any data file that calls it.
 
 function exposeData(name, value) {
-    // CommonJS consumers (if a future build step requires() the file)
-    if (typeof module !== 'undefined' && module.exports) {
-        module.exports = value;
-    }
-    // Browser: attach to window for the inline data-driven page
     if (typeof window !== 'undefined') {
         window[name] = value;
     }
     return value;
 }
 
-if (typeof module !== 'undefined' && module.exports) {
-    module.exports = exposeData;
-}
 if (typeof window !== 'undefined') {
     window.exposeData = exposeData;
 }


### PR DESCRIPTION
## Summary

Removes two never-working CommonJS compatibility branches surfaced by `/codebase-audit` (#49). This is a static site with no build step and no Node/CommonJS consumer of these files — the browser `<script src>` path in `workshop.html`/`index.html` is the only real deployment path.

- **`data/_export.js`** — `exposeData()` closes over *this file's own* `module`, so `module.exports = value` inside it could never reach a data file's own `module.exports`. Requiring a data file directly always returned `{}`, despite the comment promising a dual `window`/`module.exports` export. Removed the dead branch rather than making it real, since nothing consumes it.
- **`config/workshops-index-config.js`** — advertised a Node/CommonJS fallback ("standalone Node.js requires"), but top-level unguarded `window.WORKSHOP_CONFIG_*` reads throw `ReferenceError: window is not defined` long before the `module.exports` line is reached. Removed the stale export block and corrected the misleading comment on `_field()`.
- Updated `README.md`, `WORKSHOP_STRUCTURE.md`, and `CLAUDE.md` references that documented the now-removed dual-export claim.

No behavioral change to the real (browser) deployment path.

## Validation

- **Syntax:** `node --check data/_export.js` and `node --check config/workshops-index-config.js` both pass.
- **Behavioral (headless Chrome, local static server on `index.html` and `workshop.html?w=virtual-communication`):** index page renders all 3 workshop cards with correct titles/dates/descriptions derived from `window.WORKSHOP_CONFIG_*`; workshop page renders hero, video embed, and the full testimonials grid (sourced via `exposeData()`); console shows zero errors on either page.
- **Sanity sweep:** `git diff` is scoped to exactly the two audited files plus their doc references (README/WORKSHOP_STRUCTURE/CLAUDE.md) — no unrelated edits, no dependency changes, no weakened assertions.
- **CI:** this repo has no `.github/workflows` — nothing to wait for.

Closes #49