### PR TITLE
docs: add docs/architecture.mmd internal-architecture diagram

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,10 @@ A multi-workshop landing site for Roberto Ferraro's professional-development wor
   - `<slug>-testimonials.js`, `<slug>-benefits.js` — per-workshop content; `illustrations.js` is shared.
 - `js/` — `main.js` (populates the template), `workshop-index.js`, `iframe-resize.js` (`sendHeight()` postMessage for Squarespace embedding), `linkedin-fix.js` (opens CTAs in the system browser from LinkedIn/WebView).
 
+## Internal architecture
+
+[`docs/architecture.mmd`](docs/architecture.mmd) is a hand-authored Mermaid diagram of this repo's own internal structure (entry pages, `config/`, `data/`, `js/`, `css/`, and external dependencies like Luma/Netlify/Squarespace). Update it in the same PR as any material structural change (a new workshop slug, a renamed data/config file, a new external dependency) — same anti-staleness contract as this repo's own `.fleet.toml` `description` field. It is not auto-generated and not covered by any test suite.
+
 ## Conventions
 
 - **Data-driven, no HTML edits for content.** To change a workshop, edit `config/<slug>-config.js` and `data/<slug>-*.js` — `workshop.html` is a template and stays untouched.

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -1,0 +1,82 @@
+%% docs/architecture.mmd — this repo's own internal structure.
+%% Hand-authored, not generated — unlike a fleet-wide aggregated map, this
+%% repo's own internal shape is semantic and can't be crawled the same way.
+%% Update this diagram in the same PR as any material structural change (a
+%% new workshop slug, a renamed data/config file, a new external dependency)
+%% — same anti-staleness contract as this repo's own `.fleet.toml`
+%% `description` field. See global-CLAUDE.md's "Every repo carries a
+%% `.fleet.toml`" section for the general convention.
+
+flowchart TB
+  subgraph entry["Entry pages"]
+    INDEX["index.html\nworkshop index / landing page"]
+    SHIMS["virtual-communication.html · personal-branding.html ·\ndigital-leadership.html\nthin redirect shims"]
+  end
+
+  TEMPLATE["workshop.html\nsingle template, selects per-slug scripts\nfrom the ?w=&lt;slug&gt; query param"]
+  SHIMS -->|window.location.replace| TEMPLATE
+
+  subgraph config["config/"]
+    BASE["workshop-base.js\ncreateWorkshopConfig() deep-merge + buildLumaUrl()"]
+    WCONFIG["&lt;slug&gt;-config.js\nper-workshop overrides: dates, pricing,\nvideo, SEO meta, Luma eventUrl"]
+    IDXCONFIG["workshops-index-config.js\nindex-page card data"]
+  end
+  WCONFIG -->|calls| BASE
+
+  subgraph data["data/"]
+    EXPORT["_export.js\nexposeData(name, value) sets window[name]"]
+    CONTENT["&lt;slug&gt;-testimonials.js · &lt;slug&gt;-benefits.js"]
+    ILLUS["illustrations.js\nshared across all workshops"]
+  end
+  CONTENT -->|uses| EXPORT
+
+  TEMPLATE -->|script src, in order| BASE
+  TEMPLATE -->|script src| EXPORT
+  TEMPLATE -->|document.write, per slug| WCONFIG
+  TEMPLATE -->|document.write, per slug| CONTENT
+  TEMPLATE --> ILLUS
+  INDEX --> BASE
+  INDEX --> WCONFIG
+  INDEX --> IDXCONFIG
+
+  subgraph js["js/"]
+    MAIN["main.js\nreads window.WORKSHOP_CONFIG + data globals,\npopulates DOM: meta, copy, illustrations,\nbenefits, testimonials, pricing, video"]
+    IDXJS["workshop-index.js\nreads window.WORKSHOPS_INDEX_CONFIG,\nrenders the workshops grid"]
+    LIFIX["linkedin-fix.js\nopens CTA links in the system browser\nwhen loaded inside LinkedIn's in-app webview"]
+    RESIZE["iframe-resize.js\npostMessage(setHeight) to the parent frame"]
+  end
+  TEMPLATE --> MAIN
+  TEMPLATE --> LIFIX
+  TEMPLATE --> RESIZE
+  INDEX --> IDXJS
+  INDEX --> LIFIX
+  INDEX --> RESIZE
+  MAIN -->|reads| WCONFIG
+  MAIN -->|reads| CONTENT
+  MAIN -->|reads| ILLUS
+  IDXJS -->|reads| IDXCONFIG
+
+  subgraph css["css/"]
+    STYLES["styles.css\nshared workshop page styles,\nblack/white + yellow #FFCC00 accent"]
+    IDXCSS["workshop-index.css\nper-workshop accent gradients"]
+  end
+  TEMPLATE --> STYLES
+  INDEX --> STYLES
+  INDEX --> IDXCSS
+
+  subgraph external["External dependencies"]
+    LUMA["Luma\nticketing/checkout — buildLumaUrl() target"]
+    YT["YouTube\nembedded workshop teaser video"]
+    GFONTS["Google Fonts\nPoppins"]
+    NETLIFY["Netlify\nstatic hosting — robertoferraro.net"]
+    SQSP["Squarespace\nparent page embeds via iframe"]
+    LINKEDIN["LinkedIn in-app webview\nsource of the linkedin-fix.js redirect"]
+  end
+  BASE -->|eventUrl + utm params| LUMA
+  MAIN --> YT
+  TEMPLATE -.-> GFONTS
+  INDEX -.-> GFONTS
+  NETLIFY -->|serves| INDEX
+  NETLIFY -->|serves| TEMPLATE
+  SQSP -->|embeds, receives postMessage| RESIZE
+  LINKEDIN -->|detected by| LIFIX


### PR DESCRIPTION
## Summary
- Adds `docs/architecture.mmd`, a hand-authored Mermaid flowchart of this repo's own internal structure: entry pages (`index.html`, redirect shims), `workshop.html` template, `config/`, `data/`, `js/`, `css/`, and external dependencies (Luma, YouTube, Google Fonts, Netlify, Squarespace, LinkedIn in-app webview).
- Adds an "Internal architecture" section to `CLAUDE.md` pointing at the diagram, with the anti-staleness contract (update it in the same PR as any material structural change) — same pattern as this repo's own `.fleet.toml` `description` field.
- Companion to the fleet-wide convention established in `ferraroroberto/fleet-config#256`.

## Validation
- This repo's `CLAUDE.md` declares no formal verification gate (no test suite, no CI workflow — `.github/workflows/` does not exist in this repo). The change is docs-only (one new `.mmd` file + a `CLAUDE.md` section), so the `package.json` `lint:js`/`lint:css`/`validate` scripts (which target `js/`, `css/`, `*.html`) are not applicable — no code was touched.
- Mermaid syntax validated by actually rendering `docs/architecture.mmd` to SVG with `@mermaid-js/mermaid-cli` (using the machine's local Chrome, since headless Chromium wasn't preinstalled) — it rendered cleanly as a `flowchart-v2` SVG with all 6 subgraphs and 20 nodes, confirming valid Mermaid syntax.
- Manually cross-checked every node/edge in the diagram against the actual script-load order in `workshop.html` / `index.html` and the file purposes documented in `CLAUDE.md`.
- `git diff main...HEAD` reviewed — scoped to exactly the two intended files, no unrelated changes.

## Test plan
- [x] `docs/architecture.mmd` exists and is valid Mermaid (rendered to SVG without error).
- [x] This repo's own `CLAUDE.md` references it, with the anti-staleness line.

Closes #52